### PR TITLE
Add Redis service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,5 +17,23 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7.4-alpine
+    container_name: careerk-redis
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:-redis_password} --appendonly yes --appendfsync everysec
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-redis_password}
+    ports:
+      - '6379:6379'
+    volumes:
+      - careerk-redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
+      interval: 30s
+      timeout: 3s
+      retries: 5
+
 volumes:
   careerk-pgdata:
+  careerk-redis-data:


### PR DESCRIPTION
Expose Redis on 6379 with a persistent volume and healthcheck. Enable AOF persistence with appendfsync everysec.