### PR TITLE
Sanitize responses to remove sensitive fields

### DIFF
--- a/src/modules/iam/authentication/authentication.service.ts
+++ b/src/modules/iam/authentication/authentication.service.ts
@@ -86,9 +86,8 @@ export class AuthenticationService {
         type: UserType.JOB_SEEKER,
       });
 
-      const { password, ...result } = jobSeeker;
       return {
-        ...result,
+        ...jobSeeker,
         accessToken,
         refreshToken,
       };


### PR DESCRIPTION
Add removeSensitiveFields to ResponseInterceptor to strip configured sensitive fields (currently 'password') from response payloads, including
arrays. Remove manual password omission in AuthenticationService so sanitization is centralized.