### PR TITLE
Add CA certs to image and rename Prisma field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV HUSKY=0
 
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/* \
+  && corepack enable \
+  && corepack prepare pnpm@9.0.0 --activate
 
 WORKDIR /app
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,7 @@ model JobSeeker {
   updatedAt       DateTime  @updatedAt @map("updated_at")
 
   profile JobSeekerProfile?
-  notificationPreference JobSeekerNotificationPreference?
+  jobSeekerNotificationPreference JobSeekerNotificationPreference?
 
   educations Education[]
   workExperiences WorkExperience[]


### PR DESCRIPTION
Install openssl and ca-certificates with apt-get and remove apt lists. Keep the image small; Corepack pnpm setup is unchanged.

Rename JobSeeker.notificationPreference to
jobSeekerNotificationPreference in schema.prisma for clearer naming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build process with enhanced dependency management and optimized layer caching for faster builds
  * Updated JobSeeker model field naming for API consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->