### PR TITLE
Add media storage and image upload flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=change-me
 R2_SECRET_ACCESS_KEY=change-me
 R2_BUCKET_NAME=cvs
+R2_MEDIA_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
+R2_MEDIA_ACCESS_KEY_ID=change-me
+R2_MEDIA_SECRET_ACCESS_KEY=change-me
+R2_MEDIA_BUCKET_NAME=careerk-media
+R2_MEDIA_PUBLIC_BASE_URL=https://your-public-media-bucket.r2.dev
 
 NLP_API_URL=http://localhost:8000
 GROQ_API_KEY=change-me

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,333 @@
+# AGENTS.md - CareerK Backend Development Guide
+
+This file provides guidelines for AI agents working in this codebase.
+
+## Project Overview
+
+- **Framework**: NestJS 11 with TypeScript
+- **Database**: PostgreSQL with Prisma ORM
+- **Package Manager**: pnpm
+- **Test Framework**: Jest
+- **Linting**: ESLint + Prettier (Prettier rules enforced as ESLint errors)
+
+## Build/Lint/Test Commands
+
+```bash
+# Build
+pnpm run build                    # Nest build → dist/
+
+# Lint & Format
+pnpm run lint                     # ESLint with --fix
+pnpm run format                   # Prettier write
+
+# Start
+pnpm run start                    # nest start
+pnpm run start:dev                # nest start --watch (development)
+pnpm run start:debug              # nest start --debug --watch
+pnpm run start:prod               # node dist/main
+
+# Testing
+pnpm run test                     # Run all unit tests
+pnpm run test:watch               # Watch mode for development
+pnpm run test:cov                 # Coverage report
+pnpm run test:e2e                 # End-to-end tests (jest-e2e.json)
+pnpm run test:debug               # Debug with node --inspect-brk
+
+# Run single test file
+pnpm test -- src/modules/jobs/job.service.spec.ts
+pnpm test -- --testPathPattern=authentication.service
+
+# Database
+pnpm run seed:db                  # Seed database (node scripts/seed.js)
+```
+
+## Test Conventions
+
+- **Unit tests**: `*.spec.ts` files co-located with source
+- **E2E tests**: `*.e2e-spec.ts` in `/test` directory
+- **Jest config**: In `package.json` (rootDir: `src`, pattern: `.*\.spec\.ts$`)
+- **E2E config**: `test/jest-e2e.json` (rootDir: `.`)
+
+## Code Style Guidelines
+
+### TypeScript & Formatting
+
+```json
+// .prettierrc
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}
+```
+
+- Use `singleQuote` for strings
+- Use `trailingComma` in multiline objects/arrays
+- Maximum line length: 100 characters
+- **Prettier is enforced as ESLint errors** (`prettier/prettier: error`)
+- ESLint `endOfLine: auto` handles cross-platform line endings
+
+### TypeScript Settings (tsconfig.json)
+
+```json
+{
+  "strictNullChecks": true,
+  "noImplicitAny": false,
+  "experimentalDecorators": true,
+  "emitDecoratorMetadata": true
+}
+```
+
+- Null checks are strict; always handle `null`/`undefined`
+- `any` is allowed but avoid when possible
+- Decorators enabled for class-validator/class-transformer
+
+### ESLint Rules
+
+- `@typescript-eslint/no-explicit-any`: OFF
+- `@typescript-eslint/no-floating-promises`: WARN
+- `@typescript-eslint/no-unsafe-argument`: WARN
+- `@typescript-eslint/no-unused-vars`: ERROR (ignores rest siblings)
+
+## Import Conventions
+
+Organize imports in this order (enforced by automatic sorting):
+
+```typescript
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+
+// External packages
+import { IsEmail, IsNotEmpty } from 'class-validator';
+import { randomUUID } from 'node:crypto';
+import bcrypt from 'bcrypt';
+
+// Internal imports (use 'src/' prefix)
+import { JobSeekerRepository } from 'src/modules/job-seeker/repositories/job-seeker.repository';
+import { CompanyRepository } from 'src/modules/company/repositories/company.repository';
+```
+
+## Naming Conventions
+
+| Element          | Convention             | Example                        |
+| ---------------- | ---------------------- | ------------------------------ |
+| Classes          | PascalCase             | `AuthenticationService`        |
+| Variables        | camelCase              | `accessToken`, `jobSeeker`     |
+| DTOs             | PascalCase with suffix | `RegisterJobSeekerDto`         |
+| Enums            | PascalCase             | `UserType`, `TokenType`        |
+| Enum values      | UPPER_SNAKE_CASE       | `USER_TYPE.JOB_SEEKER`         |
+| Files            | kebab-case             | `job-seeker.service.ts`        |
+| Database columns | snake_case             | `created_at`, `user_id`        |
+| API routes       | kebab-case plural      | `/job-seekers`, `/direct-jobs` |
+
+## Module Architecture
+
+```
+src/
+├── app.module.ts
+├── main.ts
+├── core/                    # Shared utilities
+├── infrastructure/          # External services
+│   ├── database/            # Prisma client
+│   ├── redis/               # Redis client
+│   ├── queue/               # BullMQ configuration
+│   ├── email/               # Nodemailer transport
+│   ├── cv-storage/          # S3/R2 presigned URLs
+│   └── nlp/                 # CV parsing client
+└── modules/
+    ├── iam/                 # Authentication, OTP, JWT, hashing
+    ├── job-seeker/          # Profile, skills, experience, education
+    ├── company/              # Company profile, direct jobs
+    ├── jobs/                 # Public job listings, bookmarks
+    ├── cv/                   # CV upload/parse/confirm
+    └── matching/             # Job matching logic
+```
+
+## Error Handling Pattern
+
+```typescript
+// ✅ Use NestJS built-in exceptions
+throw new NotFoundException(`Job with ID ${jobId} not found`);
+throw new UnauthorizedException('Invalid credentials');
+throw new BadRequestException('Invalid input');
+throw new ConflictException('Resource already exists');
+
+// ✅ Catch and re-throw domain exceptions
+try {
+  const user = await this.userRepository.findByEmail(email);
+} catch (err) {
+  if (err instanceof HttpException) throw err;
+  throw new InternalServerErrorException('Operation failed');
+}
+
+// ❌ Don't expose internal errors to clients
+catch (err) {
+  console.error(err);  // Log internally
+  throw new InternalServerErrorException();  // Generic message only
+}
+```
+
+## DTOs & Validation
+
+Use `class-validator` decorators for all DTOs:
+
+```typescript
+export class CreateJobDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(10)
+  @MaxLength(100)
+  title: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsUUID('4', { each: true })
+  skillIds: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  salaryMin?: number;
+}
+```
+
+- Use `PartialType()` for update DTOs
+- Use `PickType()` / `OmitType()` for subsets
+- Always use `@Transform()` from class-transformer for query params
+
+## Repository Pattern
+
+```typescript
+@Injectable()
+export class JobSeekerRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findByEmail(email: string) {
+    return this.prisma.jobSeeker.findUnique({ where: { email } });
+  }
+
+  async create(data: Prisma.JobSeekerCreateInput) {
+    return this.prisma.jobSeeker.create({ data });
+  }
+}
+```
+
+- Repositories handle all database access
+- Services use repositories, never Prisma directly
+- Use Prisma's typed client from `generated/prisma`
+
+## Queue Jobs (BullMQ)
+
+```typescript
+// Add job to queue
+await this.emailQueue.add(JOB_NAME, payload as JobData, {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 2000 },
+  removeOnComplete: true,
+});
+
+// Processor
+@Processor(QUEUE_NAME)
+export class EmailProcessor {
+  @Process(JOB_NAME)
+  async handleJob(job: Job<SendVerificationEmailJob>) {
+    // Process job data
+  }
+}
+```
+
+## Guard & Decorator Usage
+
+```typescript
+// Use guards for auth
+@UseGuards(JwtAuthGuard)
+
+// Use decorators for roles
+@Roles(UserType.COMPANY)
+@UseGuards(JwtAuthGuard, RolesGuard)
+
+// Extract user data
+@Get('profile')
+getProfile(@CurrentUser() user: ActiveUserData) {
+  return { userId: user.sub, email: user.email };
+}
+```
+
+## Configuration
+
+Use `@nestjs/config` with typed configs:
+
+```typescript
+// jwt.config.ts
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('jwt', () => ({
+  secret: process.env.JWT_SECRET,
+  issuer: process.env.JWT_ISSUER,
+  expiresIn: process.env.JWT_EXPIRES_IN || '15m',
+}));
+
+// Usage
+@Inject(jwtConfig.KEY) private readonly config: ConfigType<typeof jwtConfig>
+```
+
+## Testing Guidelines
+
+```typescript
+describe('AuthenticationService', () => {
+  let service: AuthenticationService;
+  let mockRepository: jest.Mocked<JobSeekerRepository>;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        AuthenticationService,
+        { provide: JobSeekerRepository, useValue: mockRepository },
+      ],
+    }).compile();
+
+    service = module.get<AuthenticationService>(AuthenticationService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});
+```
+
+- Use `jest.fn()` for simple mocks
+- Use `jest.Mocked<T>` for typed mocks
+- Co-locate spec files with source files
+- Test happy path, errors, and edge cases
+
+## Pre-commit Hooks
+
+Husky runs lint-staged on commit:
+
+```json
+{
+  "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"]
+}
+```
+
+- ESLint fixes are applied automatically
+- Prettier formats code
+- Both run on staged files only
+
+## Key Files
+
+| File                   | Purpose                            |
+| ---------------------- | ---------------------------------- |
+| `package.json`         | Scripts, dependencies, Jest config |
+| `eslint.config.mjs`    | ESLint + Prettier configuration    |
+| `.prettierrc`          | Prettier formatting rules          |
+| `tsconfig.json`        | TypeScript compiler options        |
+| `prisma/schema.prisma` | Database schema                    |
+| `docs.json`            | Mintlify documentation navigation  |
+
+## Documentation
+
+- API docs built with Mintlify in `/docs`
+- Run `pnpm run start:dev` and visit Mintlify local server
+- Update `docs.json` to add new documentation pages

--- a/docs.json
+++ b/docs.json
@@ -61,6 +61,9 @@
               "docs/api-reference/job-seeker/get-my-profile",
               "docs/api-reference/job-seeker/get-profile-by-id",
               "docs/api-reference/job-seeker/update-profile",
+              "docs/api-reference/job-seeker/request-profile-image-upload-url",
+              "docs/api-reference/job-seeker/upload-profile-image-file",
+              "docs/api-reference/job-seeker/confirm-profile-image-upload",
               "docs/api-reference/job-seeker/deactivate-account",
               "docs/api-reference/job-seeker/get-notification-preference",
               "docs/api-reference/job-seeker/update-notification-preference"
@@ -139,6 +142,9 @@
               "docs/api-reference/company/get-company-by-id",
               "docs/api-reference/company/get-my-profile",
               "docs/api-reference/company/update-profile",
+              "docs/api-reference/company/request-image-upload-url",
+              "docs/api-reference/company/upload-image-file",
+              "docs/api-reference/company/confirm-image-upload",
               "docs/api-reference/company/deactivate-account"
             ]
           },

--- a/docs/api-reference/auth/login.mdx
+++ b/docs/api-reference/auth/login.mdx
@@ -71,7 +71,6 @@ interface CompanyLoginResponse {
     name: string;
     description: string | null;
     logoUrl: string | null;
-    coverUrl: string | null;
     industry: string;
     size: 'SIZE_1_50' | 'SIZE_51_200' | 'SIZE_201_1000' | 'SIZE_1000_PLUS';
     type: 'STARTUP' | 'SCALE_UP' | 'ENTERPRISE' | 'NON_PROFIT' | 'GOVERNMENT';
@@ -135,7 +134,6 @@ interface CompanyLoginResponse {
     "name": "TechCorp Inc.",
     "description": null,
     "logoUrl": null,
-    "coverUrl": null,
     "industry": "Technology",
     "size": "SIZE_51_200",
     "type": "STARTUP",
@@ -232,10 +230,6 @@ interface CompanyLoginResponse {
 
     <ResponseField name="logoUrl" type="string | null">
       URL to company logo.
-    </ResponseField>
-
-    <ResponseField name="coverUrl" type="string | null">
-      URL to company cover image.
     </ResponseField>
 
     <ResponseField name="industry" type="string">
@@ -459,7 +453,6 @@ interface CompanyLoginResponse {
     name: string;
     description: string | null;
     logoUrl: string | null;
-    coverUrl: string | null;
     industry: string;
     size: 'SIZE_1_50' | 'SIZE_51_200' | 'SIZE_201_1000' | 'SIZE_1000_PLUS';
     type: 'STARTUP' | 'SCALE_UP' | 'ENTERPRISE' | 'NON_PROFIT' | 'GOVERNMENT';

--- a/docs/api-reference/auth/register-company.mdx
+++ b/docs/api-reference/auth/register-company.mdx
@@ -102,7 +102,7 @@ interface RegisterCompanyResponse {
 <Steps>
   <Step title="Company Account Created">
     Company account is created in database with: - `isVerified: false` - `isActive: true` - All
-    optional fields set to `null` (description, logoUrl, coverUrl, etc.)
+    optional fields set to `null` (description, logoUrl, etc.)
   </Step>
 
 <Step title="Password Hashed">Password is securely hashed using bcrypt before storage</Step>

--- a/docs/api-reference/auth/verify-email.mdx
+++ b/docs/api-reference/auth/verify-email.mdx
@@ -71,7 +71,6 @@ interface CompanyVerifyResponse {
     name: string;
     description: string | null;
     logoUrl: string | null;
-    coverUrl: string | null;
     industry: string;
     size: CompanySize;
     type: CompanyType;
@@ -135,7 +134,6 @@ interface CompanyVerifyResponse {
     "name": "TechCorp Inc.",
     "description": null,
     "logoUrl": null,
-    "coverUrl": null,
     "industry": "Technology",
     "size": "SIZE_51_200",
     "type": "STARTUP",
@@ -232,10 +230,6 @@ interface CompanyVerifyResponse {
 
     <ResponseField name="logoUrl" type="string | null">
       URL to company logo. `null` if not set.
-    </ResponseField>
-
-    <ResponseField name="coverUrl" type="string | null">
-      URL to company cover image. `null` if not set.
     </ResponseField>
 
     <ResponseField name="industry" type="string">

--- a/docs/api-reference/company/confirm-image-upload.mdx
+++ b/docs/api-reference/company/confirm-image-upload.mdx
@@ -1,0 +1,156 @@
+---
+title: 'Confirm Company Logo Upload'
+api: 'POST /api/v1/companies/me/images/confirm'
+description: 'Confirm a previously uploaded company logo'
+---
+
+## Endpoint
+
+```http
+POST /api/v1/companies/me/images/confirm
+```
+
+**Base URL**: `http://localhost:3000/api/v1`
+
+<Note>This endpoint requires **authentication** and **Company role**.</Note>
+
+## Authentication
+
+Include the access token in the Authorization header:
+
+```bash
+Authorization: Bearer YOUR_ACCESS_TOKEN
+```
+
+## Description
+
+Confirms that the company logo exists in storage and saves its public URL to `logoUrl`.
+
+## Request Body
+
+<ParamField body="key" type="string" required>
+  Storage object key returned by the presigned URL endpoint. It must start with
+  `company-logos/{companyId}/`.
+</ParamField>
+
+## Request Shape
+
+```typescript
+interface ConfirmCompanyImageUploadDto {
+  key: string;
+}
+```
+
+## Request Example
+
+```json
+{
+  "key": "company-logos/dfb97b50-e8ff-4fa4-a9d6-ae0e9d901234/1776332930558-logo.png"
+}
+```
+
+## Response
+
+### Success Response (200 OK)
+
+```json
+{
+  "success": true,
+  "data": {
+    "fileUrl": "https://pub-5c37ea83b99f48918e67ed5fdda1be98.r2.dev/company-logos/dfb97b50-e8ff-4fa4-a9d6-ae0e9d901234/1776332930558-logo.png"
+  },
+  "message": "Company image uploaded successfully",
+  "meta": {
+    "timestamp": "2026-04-16T10:12:00.000Z",
+    "path": "/companies/me/images/confirm",
+    "method": "POST"
+  }
+}
+```
+
+## Response Shape
+
+```typescript
+interface ConfirmCompanyImageUploadResponse {
+  success: true;
+  data: {
+    fileUrl: string;
+  };
+  message: 'Company image uploaded successfully';
+  meta: {
+    timestamp: string;
+    path: '/companies/me/images/confirm';
+    method: 'POST';
+  };
+}
+```
+
+## Error Responses
+
+### 400 Bad Request - Invalid Key
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Invalid company image key",
+    "statusCode": 400,
+    "timestamp": "2026-04-16T10:12:00.000Z",
+    "path": "/companies/me/images/confirm",
+    "method": "POST"
+  }
+}
+```
+
+### 400 Bad Request - Missing File
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "File not found in storage, upload may have failed",
+    "statusCode": 400,
+    "timestamp": "2026-04-16T10:12:00.000Z",
+    "path": "/companies/me/images/confirm",
+    "method": "POST"
+  }
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Unauthorized",
+    "statusCode": 401,
+    "timestamp": "2026-04-16T10:12:00.000Z",
+    "path": "/companies/me/images/confirm",
+    "method": "POST"
+  }
+}
+```
+
+### 404 Not Found
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Company not found",
+    "statusCode": 404,
+    "timestamp": "2026-04-16T10:12:00.000Z",
+    "path": "/companies/me/images/confirm",
+    "method": "POST"
+  }
+}
+```
+
+## Flow Summary
+
+<Steps>
+  <Step title="Request URL">Call POST /companies/me/images/presigned-url</Step>
+  <Step title="Upload File">Upload the image to the returned `uploadUrl` using PUT. See /api-reference/company/upload-image-file</Step>
+  <Step title="Confirm Upload">Call POST /companies/me/images/confirm with the returned `key`</Step>
+</Steps>

--- a/docs/api-reference/company/get-all-companies.mdx
+++ b/docs/api-reference/company/get-all-companies.mdx
@@ -61,7 +61,6 @@ GET /api/v1/companies
         "name": "Tech Corp",
         "description": "A leading technology company",
         "logoUrl": "https://...",
-        "coverUrl": "https://...",
         "industry": "Technology",
         "size": "SIZE_201_1000",
         "type": "ENTERPRISE",

--- a/docs/api-reference/company/get-company-by-id.mdx
+++ b/docs/api-reference/company/get-company-by-id.mdx
@@ -30,7 +30,6 @@ GET /api/v1/companies/:id
     "name": "Tech Corp",
     "description": "A leading technology company",
     "logoUrl": "https://...",
-    "coverUrl": "https://...",
     "industry": "Technology",
     "size": "SIZE_201_1000",
     "type": "ENTERPRISE",

--- a/docs/api-reference/company/get-my-profile.mdx
+++ b/docs/api-reference/company/get-my-profile.mdx
@@ -31,7 +31,6 @@ GET /api/v1/companies/me
     "name": "Tech Corp",
     "description": "A leading technology company",
     "logoUrl": "https://...",
-    "coverUrl": "https://...",
     "industry": "Technology",
     "size": "SIZE_201_1000",
     "type": "ENTERPRISE",

--- a/docs/api-reference/company/introduction.mdx
+++ b/docs/api-reference/company/introduction.mdx
@@ -15,6 +15,9 @@ The Company API allows companies to manage their profiles, job postings, and app
 | GET    | `/companies/{id}` | Get company by ID                 |
 | GET    | `/companies/me`   | Get authenticated company profile |
 | PATCH  | `/companies/me`   | Update company profile            |
+| POST   | `/companies/me/images/presigned-url` | Request company logo upload URL |
+| PUT    | `{uploadUrl}` | Upload company logo to storage |
+| POST   | `/companies/me/images/confirm` | Confirm company logo upload |
 | DELETE | `/companies/me`   | Deactivate company account        |
 
 ## Authentication

--- a/docs/api-reference/company/request-image-upload-url.mdx
+++ b/docs/api-reference/company/request-image-upload-url.mdx
@@ -1,0 +1,133 @@
+---
+title: 'Request Company Logo Upload URL'
+api: 'POST /api/v1/companies/me/images/presigned-url'
+description: 'Request a presigned URL for uploading a company logo'
+---
+
+## Endpoint
+
+```http
+POST /api/v1/companies/me/images/presigned-url
+```
+
+**Base URL**: `http://localhost:3000/api/v1`
+
+<Note>This endpoint requires **authentication** and **Company role**.</Note>
+
+## Authentication
+
+Include the access token in the Authorization header:
+
+```bash
+Authorization: Bearer YOUR_ACCESS_TOKEN
+```
+
+## Description
+
+Requests a presigned URL for uploading a company logo directly to Cloudflare R2.
+
+## Request Body
+
+<ParamField body="fileName" type="string" required>
+  Original image file name, for example `logo.png`.
+</ParamField>
+
+<ParamField body="mimeType" type="string" required>
+  Image MIME type. Supported values: `image/jpeg`, `image/png`, `image/webp`.
+</ParamField>
+
+## Request Shape
+
+```typescript
+interface RequestCompanyImageUploadDto {
+  fileName: string;
+  mimeType: 'image/jpeg' | 'image/png' | 'image/webp';
+}
+```
+
+## Request Example
+
+```json
+{
+  "fileName": "logo.png",
+  "mimeType": "image/png"
+}
+```
+
+## Response
+
+### Success Response (200 OK)
+
+```json
+{
+  "success": true,
+  "data": {
+    "uploadUrl": "https://careerk-media.c0485e90a90f9be9ecd4e72559fee834.r2.cloudflarestorage.com/company-logos/dfb97b50-e8ff-4fa4-a9d6-ae0e9d901234/1776332930558-logo.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=a14238f39390c8c7f0581e7801787531%2F20260416%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260416T094850Z&X-Amz-Expires=3600&X-Amz-Signature=fd8f2606c79dc66b24a5b7ffffa07a9528217de6b00bc631cedc548f93173af6&X-Amz-SignedHeaders=host&x-id=PutObject",
+    "key": "company-logos/dfb97b50-e8ff-4fa4-a9d6-ae0e9d901234/1776332930558-logo.png",
+    "fileUrl": "https://pub-5c37ea83b99f48918e67ed5fdda1be98.r2.dev/company-logos/dfb97b50-e8ff-4fa4-a9d6-ae0e9d901234/1776332930558-logo.png"
+  },
+  "message": "Company image upload URL generated successfully",
+  "meta": {
+    "timestamp": "2026-04-16T10:10:00.000Z",
+    "path": "/companies/me/images/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+## Response Shape
+
+```typescript
+interface RequestCompanyImageUploadResponse {
+  success: true;
+  data: {
+    uploadUrl: string;
+    key: string;
+    fileUrl: string;
+  };
+  message: 'Company image upload URL generated successfully';
+  meta: {
+    timestamp: string;
+    path: '/companies/me/images/presigned-url';
+    method: 'POST';
+  };
+}
+```
+
+## Error Responses
+
+### 400 Bad Request - Invalid MIME Type
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": ["mimeType must be one of the following values: image/jpeg, image/png, image/webp"],
+    "statusCode": 400,
+    "timestamp": "2026-04-16T10:10:00.000Z",
+    "path": "/companies/me/images/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Unauthorized",
+    "statusCode": 401,
+    "timestamp": "2026-04-16T10:10:00.000Z",
+    "path": "/companies/me/images/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+## Next Steps
+
+1. Upload the raw file to `uploadUrl` using `PUT` (see [Upload Company Image File](/api-reference/company/upload-image-file))
+2. Do not send a bearer token to the storage URL
+3. Confirm the upload using [Confirm Company Image Upload](/api-reference/company/confirm-image-upload)

--- a/docs/api-reference/company/update-profile.mdx
+++ b/docs/api-reference/company/update-profile.mdx
@@ -42,10 +42,6 @@ PATCH /api/v1/companies/me
   Logo image URL.
 </ParamField>
 
-<ParamField body="coverUrl" type="string" optional>
-  Cover image URL.
-</ParamField>
-
 <ParamField body="industry" type="string" optional>
   Industry (e.g., "Technology", "Healthcare", "Finance").
 </ParamField>

--- a/docs/api-reference/company/upload-image-file.mdx
+++ b/docs/api-reference/company/upload-image-file.mdx
@@ -1,0 +1,77 @@
+---
+title: 'Upload Company Image File'
+api: 'PUT {uploadUrl}'
+description: 'Upload the company logo directly to cloud storage using the presigned URL'
+---
+
+## Endpoint
+
+```http
+PUT {uploadUrl}
+```
+
+<Note>
+  The URL is obtained from the [Request Company Image Upload URL](/api-reference/company/request-image-upload-url) endpoint.
+</Note>
+
+## Description
+
+Upload the company logo directly to Cloudflare R2 using the presigned URL. This is step 2 of the
+company logo upload flow.
+
+## Request Headers
+
+<ParamField header="Content-Type" type="string" required>
+  The image MIME type. It must match the value used when requesting the presigned URL.
+</ParamField>
+
+## Request Body
+
+Send the raw image file as the binary request body.
+
+<Warning>
+  Do not send your bearer token to the storage URL. This request goes to R2, not to the CareerK
+  API.
+</Warning>
+
+## Request Example
+
+```bash
+PUT "https://careerk-media.c0485e90a90f9be9ecd4e72559fee834.r2.cloudflarestorage.com/company-logos/dfb97b50-e8ff-4fa4-a9d6-ae0e9d901234/1776332930558-logo.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=a14238f39390c8c7f0581e7801787531%2F20260416%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260416T094850Z&X-Amz-Expires=3600&X-Amz-Signature=fd8f2606c79dc66b24a5b7ffffa07a9528217de6b00bc631cedc548f93173af6&X-Amz-SignedHeaders=host&x-id=PutObject" \
+  -H "Content-Type: image/png" \
+  --data-binary @logo.png
+```
+
+## Response
+
+### Success Response (200 OK)
+
+The upload returns an empty body with HTTP 200 on success.
+
+```text
+(empty response body)
+```
+
+## Error Responses
+
+### 403 Forbidden - Invalid Signature
+
+```json
+{
+  "Code": "SignatureDoesNotMatch",
+  "Message": "The request signature we calculated does not match the signature you provided."
+}
+```
+
+### 410 Gone - URL Expired
+
+```json
+{
+  "Code": "ExpiredToken",
+  "Message": "The provided token has expired."
+}
+```
+
+## Next Steps
+
+After uploading the file, confirm the upload using [Confirm Company Image Upload](/api-reference/company/confirm-image-upload).

--- a/docs/api-reference/job-seeker-applications/get-application-by-id.mdx
+++ b/docs/api-reference/job-seeker-applications/get-application-by-id.mdx
@@ -52,7 +52,6 @@ GET /api/v1/job-seekers/me/applications/:id
         "id": "uuid",
         "name": "Tech Corp",
         "logoUrl": "https://...",
-        "coverUrl": "https://...",
         "description": "Company description...",
         "industry": "Technology",
         "size": "SIZE_201_1000",

--- a/docs/api-reference/job-seeker/confirm-profile-image-upload.mdx
+++ b/docs/api-reference/job-seeker/confirm-profile-image-upload.mdx
@@ -1,0 +1,157 @@
+---
+title: 'Confirm Profile Image Upload'
+api: 'POST /api/v1/job-seekers/me/profile-image/confirm'
+description: 'Confirm a previously uploaded job seeker profile image'
+---
+
+## Endpoint
+
+```http
+POST /api/v1/job-seekers/me/profile-image/confirm
+```
+
+**Base URL**: `http://localhost:3000/api/v1`
+
+<Note>This endpoint requires **authentication** and **Job Seeker role**.</Note>
+
+## Authentication
+
+Include the access token in the Authorization header:
+
+```bash
+Authorization: Bearer YOUR_ACCESS_TOKEN
+```
+
+## Description
+
+Confirms that the profile image was uploaded successfully to storage and saves its public URL to
+`profileImageUrl`.
+
+## Request Body
+
+<ParamField body="key" type="string" required>
+  Storage object key returned by the presigned URL endpoint. It must start with
+  `profile-images/{jobSeekerId}/`.
+</ParamField>
+
+## Request Shape
+
+```typescript
+interface ConfirmProfileImageUploadDto {
+  key: string;
+}
+```
+
+## Request Example
+
+```json
+{
+  "key": "profile-images/f35b1c20-b18e-4902-9461-23bb653ee5fa/1776332930558-avatar.png"
+}
+```
+
+## Response
+
+### Success Response (200 OK)
+
+```json
+{
+  "success": true,
+  "data": {
+    "fileUrl": "https://pub-5c37ea83b99f48918e67ed5fdda1be98.r2.dev/profile-images/f35b1c20-b18e-4902-9461-23bb653ee5fa/1776332930558-avatar.png"
+  },
+  "message": "Profile image uploaded successfully",
+  "meta": {
+    "timestamp": "2026-04-16T10:05:00.000Z",
+    "path": "/job-seekers/me/profile-image/confirm",
+    "method": "POST"
+  }
+}
+```
+
+## Response Shape
+
+```typescript
+interface ConfirmProfileImageUploadResponse {
+  success: true;
+  data: {
+    fileUrl: string;
+  };
+  message: 'Profile image uploaded successfully';
+  meta: {
+    timestamp: string;
+    path: '/job-seekers/me/profile-image/confirm';
+    method: 'POST';
+  };
+}
+```
+
+## Error Responses
+
+### 400 Bad Request - Invalid Key
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Invalid profile image key",
+    "statusCode": 400,
+    "timestamp": "2026-04-16T10:05:00.000Z",
+    "path": "/job-seekers/me/profile-image/confirm",
+    "method": "POST"
+  }
+}
+```
+
+### 400 Bad Request - Missing File
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "File not found in storage, upload may have failed",
+    "statusCode": 400,
+    "timestamp": "2026-04-16T10:05:00.000Z",
+    "path": "/job-seekers/me/profile-image/confirm",
+    "method": "POST"
+  }
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Unauthorized",
+    "statusCode": 401,
+    "timestamp": "2026-04-16T10:05:00.000Z",
+    "path": "/job-seekers/me/profile-image/confirm",
+    "method": "POST"
+  }
+}
+```
+
+### 404 Not Found
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Job seeker profile not found",
+    "statusCode": 404,
+    "timestamp": "2026-04-16T10:05:00.000Z",
+    "path": "/job-seekers/me/profile-image/confirm",
+    "method": "POST"
+  }
+}
+```
+
+## Flow Summary
+
+<Steps>
+  <Step title="Request URL">Call POST /job-seekers/me/profile-image/presigned-url</Step>
+  <Step title="Upload File">Upload the image to the returned `uploadUrl` using PUT. See /api-reference/job-seeker/upload-profile-image-file</Step>
+  <Step title="Confirm Upload">Call POST /job-seekers/me/profile-image/confirm with the returned `key`</Step>
+</Steps>

--- a/docs/api-reference/job-seeker/request-profile-image-upload-url.mdx
+++ b/docs/api-reference/job-seeker/request-profile-image-upload-url.mdx
@@ -1,0 +1,159 @@
+---
+title: 'Request Profile Image Upload URL'
+api: 'POST /api/v1/job-seekers/me/profile-image/presigned-url'
+description: 'Request a presigned URL for uploading the authenticated job seeker profile image'
+---
+
+## Endpoint
+
+```http
+POST /api/v1/job-seekers/me/profile-image/presigned-url
+```
+
+**Base URL**: `http://localhost:3000/api/v1`
+
+<Note>This endpoint requires **authentication** and **Job Seeker role**.</Note>
+
+## Authentication
+
+Include the access token in the Authorization header:
+
+```bash
+Authorization: Bearer YOUR_ACCESS_TOKEN
+```
+
+## Description
+
+Requests a presigned URL for uploading a job seeker profile image directly to Cloudflare R2.
+
+This is step 1 of the image upload flow:
+
+1. Request presigned upload URL from API
+2. Upload file directly to storage with `PUT {uploadUrl}`
+3. Confirm upload with the API
+
+## Request Body
+
+<ParamField body="fileName" type="string" required>
+  Original image file name, for example `avatar.png`.
+</ParamField>
+
+<ParamField body="mimeType" type="string" required>
+  Image MIME type. Supported values: `image/jpeg`, `image/png`, `image/webp`.
+</ParamField>
+
+## Request Shape
+
+```typescript
+interface RequestProfileImageUploadDto {
+  fileName: string;
+  mimeType: 'image/jpeg' | 'image/png' | 'image/webp';
+}
+```
+
+## Request Example
+
+```json
+{
+  "fileName": "avatar.png",
+  "mimeType": "image/png"
+}
+```
+
+## Response
+
+### Success Response (200 OK)
+
+```json
+{
+  "success": true,
+  "data": {
+    "uploadUrl": "https://careerk-media.c0485e90a90f9be9ecd4e72559fee834.r2.cloudflarestorage.com/profile-images/f35b1c20-b18e-4902-9461-23bb653ee5fa/1776332930558-avatar.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=a14238f39390c8c7f0581e7801787531%2F20260416%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260416T094850Z&X-Amz-Expires=3600&X-Amz-Signature=fd8f2606c79dc66b24a5b7ffffa07a9528217de6b00bc631cedc548f93173af6&X-Amz-SignedHeaders=host&x-id=PutObject",
+    "key": "profile-images/f35b1c20-b18e-4902-9461-23bb653ee5fa/1776332930558-avatar.png",
+    "fileUrl": "https://pub-5c37ea83b99f48918e67ed5fdda1be98.r2.dev/profile-images/f35b1c20-b18e-4902-9461-23bb653ee5fa/1776332930558-avatar.png"
+  },
+  "message": "Profile image upload URL generated successfully",
+  "meta": {
+    "timestamp": "2026-04-16T09:48:50.575Z",
+    "path": "/job-seekers/me/profile-image/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+## Response Shape
+
+```typescript
+interface RequestProfileImageUploadResponse {
+  success: true;
+  data: {
+    uploadUrl: string;
+    key: string;
+    fileUrl: string;
+  };
+  message: 'Profile image upload URL generated successfully';
+  meta: {
+    timestamp: string;
+    path: '/job-seekers/me/profile-image/presigned-url';
+    method: 'POST';
+  };
+}
+```
+
+## Error Responses
+
+### 400 Bad Request - Invalid MIME Type
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": ["mimeType must be one of the following values: image/jpeg, image/png, image/webp"],
+    "statusCode": 400,
+    "timestamp": "2026-04-16T10:00:00.000Z",
+    "path": "/job-seekers/me/profile-image/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+### 401 Unauthorized
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Unauthorized",
+    "statusCode": 401,
+    "timestamp": "2026-04-16T10:00:00.000Z",
+    "path": "/job-seekers/me/profile-image/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+### 403 Forbidden
+
+```json
+{
+  "success": false,
+  "error": {
+    "message": "Forbidden resource",
+    "statusCode": 403,
+    "timestamp": "2026-04-16T10:00:00.000Z",
+    "path": "/job-seekers/me/profile-image/presigned-url",
+    "method": "POST"
+  }
+}
+```
+
+## Next Steps
+
+1. Upload the raw file to `uploadUrl` using `PUT` (see [Upload Profile Image File](/api-reference/job-seeker/upload-profile-image-file))
+2. Do not send a bearer token to the storage URL
+3. Confirm the upload using [Confirm Profile Image Upload](/api-reference/job-seeker/confirm-profile-image-upload)
+
+<Warning>
+  The direct upload request goes to storage, not to the CareerK API. Use the returned `uploadUrl`
+  exactly as-is.
+</Warning>

--- a/docs/api-reference/job-seeker/upload-profile-image-file.mdx
+++ b/docs/api-reference/job-seeker/upload-profile-image-file.mdx
@@ -1,0 +1,77 @@
+---
+title: 'Upload Profile Image File'
+api: 'PUT {uploadUrl}'
+description: 'Upload the job seeker profile image directly to cloud storage using the presigned URL'
+---
+
+## Endpoint
+
+```http
+PUT {uploadUrl}
+```
+
+<Note>
+  The URL is obtained from the [Request Profile Image Upload URL](/api-reference/job-seeker/request-profile-image-upload-url) endpoint.
+</Note>
+
+## Description
+
+Upload the profile image directly to Cloudflare R2 using the presigned URL. This is step 2 of the
+profile image upload flow.
+
+## Request Headers
+
+<ParamField header="Content-Type" type="string" required>
+  The image MIME type. It must match the value used when requesting the presigned URL.
+</ParamField>
+
+## Request Body
+
+Send the raw image file as the binary request body.
+
+<Warning>
+  Do not send your bearer token to the storage URL. This request goes to R2, not to the CareerK
+  API.
+</Warning>
+
+## Request Example
+
+```bash
+PUT "https://careerk-media.c0485e90a90f9be9ecd4e72559fee834.r2.cloudflarestorage.com/profile-images/f35b1c20-b18e-4902-9461-23bb653ee5fa/1776332930558-avatar.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=a14238f39390c8c7f0581e7801787531%2F20260416%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260416T094850Z&X-Amz-Expires=3600&X-Amz-Signature=fd8f2606c79dc66b24a5b7ffffa07a9528217de6b00bc631cedc548f93173af6&X-Amz-SignedHeaders=host&x-id=PutObject" \
+  -H "Content-Type: image/png" \
+  --data-binary @avatar.png
+```
+
+## Response
+
+### Success Response (200 OK)
+
+The upload returns an empty body with HTTP 200 on success.
+
+```text
+(empty response body)
+```
+
+## Error Responses
+
+### 403 Forbidden - Invalid Signature
+
+```json
+{
+  "Code": "SignatureDoesNotMatch",
+  "Message": "The request signature we calculated does not match the signature you provided."
+}
+```
+
+### 410 Gone - URL Expired
+
+```json
+{
+  "Code": "ExpiredToken",
+  "Message": "The provided token has expired."
+}
+```
+
+## Next Steps
+
+After uploading the file, confirm the upload using [Confirm Profile Image Upload](/api-reference/job-seeker/confirm-profile-image-upload).

--- a/docs/job-seeker/introduction.mdx
+++ b/docs/job-seeker/introduction.mdx
@@ -21,6 +21,9 @@ http://localhost:3000/api/v1
 | GET    | `/job-seekers/me`  | Get current user's profile                | Yes (Job Seeker) |
 | GET    | `/job-seekers/:id` | Get job seeker profile by ID              | No               |
 | PATCH  | `/job-seekers/me`  | Update current user's profile             | Yes (Job Seeker) |
+| POST   | `/job-seekers/me/profile-image/presigned-url` | Request profile image upload URL | Yes (Job Seeker) |
+| PUT    | `{uploadUrl}` | Upload profile image to storage | No (signed URL) |
+| POST   | `/job-seekers/me/profile-image/confirm` | Confirm profile image upload | Yes (Job Seeker) |
 | DELETE | `/job-seekers/me`  | Deactivate current user's account         | Yes (Job Seeker) |
 | GET    | `/job-seekers/me/notification-preference` | Get current notification preferences | Yes (Job Seeker) |
 | PATCH  | `/job-seekers/me/notification-preference` | Update notification preferences      | Yes (Job Seeker) |
@@ -162,6 +165,27 @@ Content-Type: application/json
   "location": "Cairo, Egypt",
   "summary": "Experienced developer..."
 }
+```
+
+### 4. Upload Profile Image
+
+```bash
+POST /api/v1/job-seekers/me/profile-image/presigned-url
+Authorization: Bearer YOUR_ACCESS_TOKEN
+Content-Type: application/json
+
+{
+  "fileName": "avatar.png",
+  "mimeType": "image/png"
+}
+```
+
+Then upload the returned `uploadUrl` with:
+
+```bash
+PUT "{uploadUrl}"
+Content-Type: image/png
+(binary file body)
 ```
 
 ## Response Format

--- a/prisma/migrations/20260416000000_remove_company_cover_url/migration.sql
+++ b/prisma/migrations/20260416000000_remove_company_cover_url/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "companies"
+DROP COLUMN "cover_url";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,6 @@ model Company {
   name                 String
   description          String?     @db.Text
   logoUrl              String?     @map("logo_url") @db.VarChar(500)
-  coverUrl             String?     @map("cover_url") @db.VarChar(500)
 
   industry             String
   size                 CompanySize

--- a/src/infrastructure/media-storage/config/media-storage.config.ts
+++ b/src/infrastructure/media-storage/config/media-storage.config.ts
@@ -1,0 +1,9 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('media', () => ({
+  endpoint: process.env.R2_MEDIA_ENDPOINT,
+  accessKeyId: process.env.R2_MEDIA_ACCESS_KEY_ID,
+  accessSecretKey: process.env.R2_MEDIA_SECRET_ACCESS_KEY,
+  bucketName: process.env.R2_MEDIA_BUCKET_NAME,
+  publicBaseUrl: process.env.R2_MEDIA_PUBLIC_BASE_URL,
+}));

--- a/src/infrastructure/media-storage/media-storage.module.ts
+++ b/src/infrastructure/media-storage/media-storage.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import mediaStorageConfig from './config/media-storage.config';
+import { MediaStorageService } from './media-storage.service';
+
+@Module({
+  imports: [ConfigModule.forFeature(mediaStorageConfig)],
+  providers: [MediaStorageService],
+  exports: [MediaStorageService],
+})
+export class MediaStorageModule {}

--- a/src/infrastructure/media-storage/media-storage.service.ts
+++ b/src/infrastructure/media-storage/media-storage.service.ts
@@ -1,0 +1,97 @@
+import { Inject, Injectable, InternalServerErrorException } from '@nestjs/common';
+import {
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { type ConfigType } from '@nestjs/config';
+import mediaStorageConfig from './config/media-storage.config';
+
+@Injectable()
+export class MediaStorageService {
+  private readonly s3Client: S3Client;
+  private readonly bucket: string;
+  private readonly publicBaseUrl: string;
+
+  constructor(
+    @Inject(mediaStorageConfig.KEY)
+    private readonly mediaStorageConfiguration: ConfigType<typeof mediaStorageConfig>,
+  ) {
+    this.s3Client = new S3Client({
+      region: 'auto',
+      endpoint: this.mediaStorageConfiguration.endpoint,
+      credentials: {
+        accessKeyId: this.mediaStorageConfiguration.accessKeyId!,
+        secretAccessKey: this.mediaStorageConfiguration.accessSecretKey!,
+      },
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
+    });
+    this.bucket = this.mediaStorageConfiguration.bucketName!;
+    this.publicBaseUrl = this.mediaStorageConfiguration.publicBaseUrl?.replace(/\/+$/, '') || '';
+  }
+
+  buildJobSeekerProfileImageKey(jobSeekerId: string, fileName: string): string {
+    return this.buildKey('profile-images', jobSeekerId, fileName);
+  }
+
+  buildCompanyLogoKey(companyId: string, fileName: string): string {
+    return this.buildKey('company-logos', companyId, fileName);
+  }
+
+  async generateUploadUrl(key: string, mimeType: string): Promise<string> {
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      ContentType: mimeType,
+    });
+
+    return getSignedUrl(this.s3Client, command, { expiresIn: 3600 });
+  }
+
+  buildFileUrl(key: string): string {
+    if (!this.publicBaseUrl) {
+      throw new InternalServerErrorException('R2 media public base URL is not configured');
+    }
+
+    return `${this.publicBaseUrl}/${key}`;
+  }
+
+  extractKeyFromFileUrl(fileUrl: string): string | null {
+    if (!this.publicBaseUrl) return null;
+
+    const prefix = `${this.publicBaseUrl}/`;
+    if (!fileUrl.startsWith(prefix)) return null;
+
+    return decodeURIComponent(fileUrl.slice(prefix.length));
+  }
+
+  async fileExists(key: string): Promise<boolean> {
+    try {
+      await this.s3Client.send(
+        new HeadObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+        }),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    await this.s3Client.send(new DeleteObjectCommand({ Bucket: this.bucket, Key: key }));
+  }
+
+  private buildKey(prefix: string, ownerId: string, fileName: string): string {
+    const safeFileName = this.sanitizeFileName(fileName);
+    return `${prefix}/${ownerId}/${Date.now()}-${safeFileName}`;
+  }
+
+  private sanitizeFileName(fileName: string): string {
+    return fileName.replace(/[^a-zA-Z0-9._-]/g, '-');
+  }
+}

--- a/src/modules/company/company.controller.ts
+++ b/src/modules/company/company.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
 import { CompanyService } from './company.service';
 import { CompanyQueryDto } from './dto/company-query.dto';
 import { UpdateCompanyProfileDto } from './dto/update-company-profile.dto';
@@ -8,6 +8,8 @@ import { ActiveUser } from '../iam/decorators/active-user.decorator';
 import { Roles } from '../iam/authentication/decorators/roles.decorator';
 import { UserType } from '../iam/enums/user-type.enum';
 import { ResponseMessage } from 'src/core/decorators/response-message.decorator';
+import { RequestCompanyImageUploadDto } from './dto/request-company-image-upload.dto';
+import { ConfirmCompanyImageUploadDto } from './dto/confirm-company-image-upload.dto';
 
 @Controller('companies')
 @Auth(AuthType.None)
@@ -51,5 +53,27 @@ export class CompanyController {
     @Body() updateCompanyProfileDto: UpdateCompanyProfileDto,
   ) {
     return this.companyService.updateMyProfile(companyId, updateCompanyProfileDto);
+  }
+
+  @Post('/me/images/presigned-url')
+  @Auth(AuthType.Bearer)
+  @Roles(UserType.COMPANY)
+  @ResponseMessage('Company image upload URL generated successfully')
+  requestImageUploadUrl(
+    @ActiveUser('sub') companyId: string,
+    @Body() requestCompanyImageUploadDto: RequestCompanyImageUploadDto,
+  ) {
+    return this.companyService.requestImageUpload(companyId, requestCompanyImageUploadDto);
+  }
+
+  @Post('/me/images/confirm')
+  @Auth(AuthType.Bearer)
+  @Roles(UserType.COMPANY)
+  @ResponseMessage('Company image uploaded successfully')
+  confirmImageUpload(
+    @ActiveUser('sub') companyId: string,
+    @Body() confirmCompanyImageUploadDto: ConfirmCompanyImageUploadDto,
+  ) {
+    return this.companyService.confirmImageUpload(companyId, confirmCompanyImageUploadDto);
   }
 }

--- a/src/modules/company/company.module.ts
+++ b/src/modules/company/company.module.ts
@@ -6,9 +6,10 @@ import { CompanyRepository } from './repositories/company.repository';
 import { CompanyRepositoryImpl } from './repositories/company.repository.impl';
 import { DirectJobModule } from './direct-jobs/direct-job.module';
 import { CompanyApplicationModule } from './application/application.module';
+import { MediaStorageModule } from 'src/infrastructure/media-storage/media-storage.module';
 
 @Module({
-  imports: [DatabaseModule, DirectJobModule, CompanyApplicationModule],
+  imports: [DatabaseModule, DirectJobModule, CompanyApplicationModule, MediaStorageModule],
   controllers: [CompanyController],
   providers: [
     CompanyService,

--- a/src/modules/company/company.service.ts
+++ b/src/modules/company/company.service.ts
@@ -1,12 +1,18 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { MediaStorageService } from 'src/infrastructure/media-storage/media-storage.service';
 import { CompanyRepository } from './repositories/company.repository';
 import { CompanyQueryDto } from './dto/company-query.dto';
 import { PublicCompanyDetails, MyCompanyProfile } from './types/company.types';
 import { UpdateCompanyProfileDto } from './dto/update-company-profile.dto';
+import { RequestCompanyImageUploadDto } from './dto/request-company-image-upload.dto';
+import { ConfirmCompanyImageUploadDto } from './dto/confirm-company-image-upload.dto';
 
 @Injectable()
 export class CompanyService {
-  constructor(private readonly companyRepository: CompanyRepository) {}
+  constructor(
+    private readonly companyRepository: CompanyRepository,
+    private readonly mediaStorageService: MediaStorageService,
+  ) {}
 
   async findAllCompanies(query: CompanyQueryDto) {
     const { page = 1, limit = 20 } = query;
@@ -46,5 +52,63 @@ export class CompanyService {
     const updated = await this.companyRepository.updateMyProfile(companyId, data);
     if (!updated) throw new NotFoundException('Failed to update company profile');
     return updated;
+  }
+
+  async requestImageUpload(
+    companyId: string,
+    requestCompanyImageUploadDto: RequestCompanyImageUploadDto,
+  ) {
+    const key = this.mediaStorageService.buildCompanyLogoKey(
+      companyId,
+      requestCompanyImageUploadDto.fileName,
+    );
+    const uploadUrl = await this.mediaStorageService.generateUploadUrl(
+      key,
+      requestCompanyImageUploadDto.mimeType,
+    );
+
+    return {
+      uploadUrl,
+      key,
+      fileUrl: this.mediaStorageService.buildFileUrl(key),
+    };
+  }
+
+  async confirmImageUpload(
+    companyId: string,
+    confirmCompanyImageUploadDto: ConfirmCompanyImageUploadDto,
+  ) {
+    const expectedPrefix = `company-logos/${companyId}/`;
+    if (!confirmCompanyImageUploadDto.key.startsWith(expectedPrefix)) {
+      throw new BadRequestException('Invalid company image key');
+    }
+
+    const exists = await this.mediaStorageService.fileExists(confirmCompanyImageUploadDto.key);
+    if (!exists) {
+      throw new BadRequestException('File not found in storage, upload may have failed');
+    }
+
+    const company = await this.companyRepository.findMyProfile(companyId);
+    if (!company) throw new NotFoundException('Company not found');
+
+    const fileUrl = this.mediaStorageService.buildFileUrl(confirmCompanyImageUploadDto.key);
+    const existingUrl = company.logoUrl;
+    const previousKey =
+      existingUrl &&
+      existingUrl !== fileUrl &&
+      this.mediaStorageService.extractKeyFromFileUrl(existingUrl);
+
+    if (previousKey) {
+      await this.mediaStorageService.deleteFile(previousKey);
+    }
+
+    const updated = await this.companyRepository.updateMyProfile(companyId, {
+      logoUrl: fileUrl,
+    });
+    if (!updated) throw new NotFoundException('Failed to update company profile');
+
+    return {
+      fileUrl,
+    };
   }
 }

--- a/src/modules/company/dto/confirm-company-image-upload.dto.ts
+++ b/src/modules/company/dto/confirm-company-image-upload.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class ConfirmCompanyImageUploadDto {
+  @IsString()
+  key: string;
+}

--- a/src/modules/company/dto/request-company-image-upload.dto.ts
+++ b/src/modules/company/dto/request-company-image-upload.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsString } from 'class-validator';
+
+const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+
+export class RequestCompanyImageUploadDto {
+  @IsString()
+  fileName: string;
+
+  @IsIn(ALLOWED_IMAGE_MIME_TYPES)
+  mimeType: string;
+}

--- a/src/modules/company/dto/update-company-profile.dto.ts
+++ b/src/modules/company/dto/update-company-profile.dto.ts
@@ -25,10 +25,6 @@ export class UpdateCompanyProfileDto {
 
   @IsOptional()
   @IsString()
-  coverUrl?: string;
-
-  @IsOptional()
-  @IsString()
   industry?: string;
 
   @IsOptional()

--- a/src/modules/company/types/company.types.ts
+++ b/src/modules/company/types/company.types.ts
@@ -14,7 +14,6 @@ export const publicCompanySelect = {
     name: true,
     description: true,
     logoUrl: true,
-    coverUrl: true,
     industry: true,
     size: true,
     type: true,
@@ -36,7 +35,6 @@ export const publicCompanyDetailsSelect = {
     name: true,
     description: true,
     logoUrl: true,
-    coverUrl: true,
     industry: true,
     size: true,
     type: true,
@@ -73,7 +71,6 @@ export const myCompanyProfileSelect = {
     name: true,
     description: true,
     logoUrl: true,
-    coverUrl: true,
     industry: true,
     size: true,
     type: true,
@@ -109,7 +106,7 @@ export type CreateCompanyData = Omit<
 >;
 
 export type UpdateCompanyData = Partial<
-  Omit<Company, 'id' | 'password' | 'email' | 'createdAt' | 'updatedAt' | 'isActive'>
+  Omit<Company, 'id' | 'password' | 'email' | 'createdAt' | 'updatedAt' | 'isActive' | 'coverUrl'>
 >;
 
 export type CompanyFilters = {

--- a/src/modules/job-seeker/application/types/application.types.ts
+++ b/src/modules/job-seeker/application/types/application.types.ts
@@ -53,7 +53,6 @@ export const applicationDetailSelect = {
             id: true,
             name: true,
             logoUrl: true,
-            coverUrl: true,
             description: true,
             industry: true,
             size: true,

--- a/src/modules/job-seeker/dto/confirm-profile-image-upload.dto.ts
+++ b/src/modules/job-seeker/dto/confirm-profile-image-upload.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class ConfirmProfileImageUploadDto {
+  @IsString()
+  key: string;
+}

--- a/src/modules/job-seeker/dto/request-profile-image-upload.dto.ts
+++ b/src/modules/job-seeker/dto/request-profile-image-upload.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsString } from 'class-validator';
+
+const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+export class RequestProfileImageUploadDto {
+  @IsString()
+  fileName: string;
+
+  @IsIn(ALLOWED_IMAGE_MIME_TYPES)
+  mimeType: string;
+}

--- a/src/modules/job-seeker/dto/update-job-seeker-profile.dto.ts
+++ b/src/modules/job-seeker/dto/update-job-seeker-profile.dto.ts
@@ -54,4 +54,8 @@ export class UpdateJobSeekerProfileDto {
   @IsOptional()
   @IsString()
   githubUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  profileImageUrl?: string;
 }

--- a/src/modules/job-seeker/job-seeker.controller.ts
+++ b/src/modules/job-seeker/job-seeker.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
 import { JobSeekerService } from './job-seeker.service';
 import { JobSeekerQueryDto } from './dto/job-seeker-query.dto';
 import { AuthType } from '../iam/enums/auth-type.enum';
@@ -8,6 +8,8 @@ import { Roles } from '../iam/authentication/decorators/roles.decorator';
 import { UserType } from '../iam/enums/user-type.enum';
 import { ResponseMessage } from 'src/core/decorators/response-message.decorator';
 import { UpdateJobSeekerProfileDto } from './dto/update-job-seeker-profile.dto';
+import { RequestProfileImageUploadDto } from './dto/request-profile-image-upload.dto';
+import { ConfirmProfileImageUploadDto } from './dto/confirm-profile-image-upload.dto';
 
 @Controller('job-seekers')
 @Auth(AuthType.None)
@@ -51,5 +53,33 @@ export class JobSeekerController {
     @Body() updateJobSeekerProfileDto: UpdateJobSeekerProfileDto,
   ) {
     return this.jobSeekerService.updateMyProfile(jobSeekerId, updateJobSeekerProfileDto);
+  }
+
+  @Post('/me/profile-image/presigned-url')
+  @Auth(AuthType.Bearer)
+  @Roles(UserType.JOB_SEEKER)
+  @ResponseMessage('Profile image upload URL generated successfully')
+  requestProfileImageUploadUrl(
+    @ActiveUser('sub') jobSeekerId: string,
+    @Body() requestProfileImageUploadDto: RequestProfileImageUploadDto,
+  ) {
+    return this.jobSeekerService.requestProfileImageUpload(
+      jobSeekerId,
+      requestProfileImageUploadDto,
+    );
+  }
+
+  @Post('/me/profile-image/confirm')
+  @Auth(AuthType.Bearer)
+  @Roles(UserType.JOB_SEEKER)
+  @ResponseMessage('Profile image uploaded successfully')
+  confirmProfileImageUpload(
+    @ActiveUser('sub') jobSeekerId: string,
+    @Body() confirmProfileImageUploadDto: ConfirmProfileImageUploadDto,
+  ) {
+    return this.jobSeekerService.confirmProfileImageUpload(
+      jobSeekerId,
+      confirmProfileImageUploadDto,
+    );
   }
 }

--- a/src/modules/job-seeker/job-seeker.module.ts
+++ b/src/modules/job-seeker/job-seeker.module.ts
@@ -12,6 +12,7 @@ import { SkillGapAnalysisModule } from './skill-gap-analysis/skill-gap-analysis.
 import { SkillGapAnalysisController } from './skill-gap-analysis/skill-gap-analysis.controller';
 import { SkillGapAnalysisOrchestratorService } from './skill-gap-analysis/skill-gap-analysis-orchestrator.service';
 import { NotificationPreferenceModule } from './notification-preference/notification-preference.module';
+import { MediaStorageModule } from 'src/infrastructure/media-storage/media-storage.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { NotificationPreferenceModule } from './notification-preference/notifica
     JobSeekerApplicationModule,
     SkillGapAnalysisModule,
     NotificationPreferenceModule,
+    MediaStorageModule,
   ],
   controllers: [JobSeekerController, SkillGapAnalysisController],
   providers: [

--- a/src/modules/job-seeker/job-seeker.service.ts
+++ b/src/modules/job-seeker/job-seeker.service.ts
@@ -1,11 +1,17 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { MediaStorageService } from 'src/infrastructure/media-storage/media-storage.service';
 import { JobSeekerRepository } from './repositories/job-seeker.repository';
 import { JobSeekerQueryDto } from './dto/job-seeker-query.dto';
 import { UpdateJobSeekerProfileDto } from './dto/update-job-seeker-profile.dto';
+import { RequestProfileImageUploadDto } from './dto/request-profile-image-upload.dto';
+import { ConfirmProfileImageUploadDto } from './dto/confirm-profile-image-upload.dto';
 
 @Injectable()
 export class JobSeekerService {
-  constructor(private readonly jobSeekerRepository: JobSeekerRepository) {}
+  constructor(
+    private readonly jobSeekerRepository: JobSeekerRepository,
+    private readonly mediaStorageService: MediaStorageService,
+  ) {}
 
   async findAllProfiles(query: JobSeekerQueryDto) {
     const { page = 1, limit = 20 } = query;
@@ -64,5 +70,62 @@ export class JobSeekerService {
 
   async deactivate(email: string) {
     return await this.jobSeekerRepository.deactivateByEmail(email);
+  }
+
+  async requestProfileImageUpload(
+    jobSeekerId: string,
+    requestProfileImageUploadDto: RequestProfileImageUploadDto,
+  ) {
+    const key = this.mediaStorageService.buildJobSeekerProfileImageKey(
+      jobSeekerId,
+      requestProfileImageUploadDto.fileName,
+    );
+
+    const uploadUrl = await this.mediaStorageService.generateUploadUrl(
+      key,
+      requestProfileImageUploadDto.mimeType,
+    );
+
+    return {
+      uploadUrl,
+      key,
+      fileUrl: this.mediaStorageService.buildFileUrl(key),
+    };
+  }
+
+  async confirmProfileImageUpload(
+    jobSeekerId: string,
+    confirmProfileImageUploadDto: ConfirmProfileImageUploadDto,
+  ) {
+    const expectedPrefix = `profile-images/${jobSeekerId}/`;
+    if (!confirmProfileImageUploadDto.key.startsWith(expectedPrefix)) {
+      throw new BadRequestException('Invalid profile image key');
+    }
+
+    const exists = await this.mediaStorageService.fileExists(confirmProfileImageUploadDto.key);
+    if (!exists) {
+      throw new BadRequestException('File not found in storage, upload may have failed');
+    }
+
+    const currentProfile = await this.jobSeekerRepository.findMyProfile(jobSeekerId);
+    if (!currentProfile) {
+      throw new NotFoundException('Job seeker profile not found');
+    }
+
+    const fileUrl = this.mediaStorageService.buildFileUrl(confirmProfileImageUploadDto.key);
+    const previousKey =
+      currentProfile.profileImageUrl &&
+      currentProfile.profileImageUrl !== fileUrl &&
+      this.mediaStorageService.extractKeyFromFileUrl(currentProfile.profileImageUrl);
+
+    if (previousKey) {
+      await this.mediaStorageService.deleteFile(previousKey);
+    }
+
+    await this.jobSeekerRepository.updateMyProfile(jobSeekerId, { profileImageUrl: fileUrl });
+
+    return {
+      fileUrl,
+    };
   }
 }

--- a/src/modules/job-seeker/repositories/job-seeker.repository.impl.ts
+++ b/src/modules/job-seeker/repositories/job-seeker.repository.impl.ts
@@ -17,11 +17,12 @@ export class JobSeekerRepositoryImpl implements JobSeekerRepository {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async updateMyProfile(jobSeekerId: string, data: UpdateMyProfileData): Promise<void> {
-    const { firstName, lastName, ...profileData } = data;
+    const { firstName, lastName, profileImageUrl, ...profileData } = data;
 
     const jobSeekerData: Prisma.JobSeekerUpdateInput = {};
-    if (firstName) jobSeekerData.firstName = firstName;
-    if (lastName) jobSeekerData.lastName = lastName;
+    if (firstName !== undefined) jobSeekerData.firstName = firstName;
+    if (lastName !== undefined) jobSeekerData.lastName = lastName;
+    if (profileImageUrl !== undefined) jobSeekerData.profileImageUrl = profileImageUrl;
 
     const hasJobSeekerUpdate = Object.keys(jobSeekerData).length > 0;
     const hasProfileUpdate = Object.keys(profileData).length > 0;

--- a/src/modules/matching/matching.module.ts
+++ b/src/modules/matching/matching.module.ts
@@ -1,15 +1,29 @@
 import { Module } from '@nestjs/common';
+import { BullModule } from '@nestjs/bullmq';
 import { MatchingController } from './matching.controller';
 import { MatchingService } from './matching.service';
 import { MatchingRepository } from './repository/matching.repository';
 import { MatchingRepositoryImpl } from './repository/matching.repository.impl';
 import { DatabaseModule } from 'src/infrastructure/database/database.module'; // use the same DatabaseModule as JobSeekerModule
+import { MatchingWebhookController } from './webhook/webhook.controller';
+import { MatchingWebhookService } from './webhook/webhook.service';
+import { MATCHING_EMAIL_QUEUE } from './jobs/queue.constants';
+import { MatchingEmailProcessor } from './processors/email.processor';
+import { EmailModule } from 'src/infrastructure/email/email.module';
 
 @Module({
-  imports: [DatabaseModule], // use DatabaseModule for DB access
-  controllers: [MatchingController],
+  imports: [
+    DatabaseModule,
+    BullModule.registerQueue({
+      name: MATCHING_EMAIL_QUEUE,
+    }),
+    EmailModule,
+  ],
+  controllers: [MatchingController, MatchingWebhookController],
   providers: [
     MatchingService,
+    MatchingWebhookService,
+    MatchingEmailProcessor,
     {
       provide: MatchingRepository,
       useClass: MatchingRepositoryImpl,


### PR DESCRIPTION
Introduce MediaStorageService, config and module; add presigned upload and confirm endpoints for job seekers and companies with DTOs and documentation. Remove companies.cover_url (Prisma migration added). Update .env.example with R2 media variables. Register matching email queue and webhook/processor, and add AGENTS.md developer guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job seekers can now upload and manage profile images through new endpoints supporting JPEG, PNG, and WebP formats.
  * Companies can now upload and manage logos through new endpoints with identical format support.

* **Updates**
  * Removed `coverUrl` field from company profile endpoints and related API responses.

* **Documentation**
  * Updated API reference documentation with detailed specifications for new profile image and logo upload endpoints, including request/response examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->