### PR TITLE
Add health endpoint and API/CORS setup

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { CvModule } from './modules/cv/cv.module';
 import { CvStorageModule } from './infrastructure/cv-storage/cv-storage.module';
 import { JobModule } from './modules/jobs/job.module';
 import { MatchingModule } from './modules/matching/matching.module';
+import { HealthController } from './health.controller';
 
 @Module({
   imports: [
@@ -40,5 +41,6 @@ import { MatchingModule } from './modules/matching/matching.module';
       useClass: HttpExceptionFilter,
     },
   ],
+  controllers: [HealthController],
 })
 export class AppModule {}

--- a/src/health.controller.ts
+++ b/src/health.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { Auth } from './modules/iam/authentication/decorators/auth.decorator';
+import { AuthType } from './modules/iam/enums/auth-type.enum';
+
+@Controller('health')
+@Auth(AuthType.None)
+export class HealthController {
+  @Get()
+  check() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,32 @@ import cookieParser from 'cookie-parser';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  app.setGlobalPrefix('/api/v1');
+
+  app.enableCors({
+    origin: (
+      origin: string | undefined,
+      callback: (err: Error | null, allow?: boolean) => void,
+    ) => {
+      const allowedProduction = process.env.FRONTEND_URL;
+
+      if (!origin) return callback(null, true);
+
+      if (allowedProduction && origin === allowedProduction) {
+        return callback(null, true);
+      }
+
+      if (/^http:\/\/localhost:\d+$/.test(origin)) {
+        return callback(null, true);
+      }
+
+      callback(new Error(`CORS blocked: ${origin}`));
+    },
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+  });
+
   app.use(cookieParser());
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
Register HealthController in AppModule. Set global prefix to /api/v1 and configure CORS to allow FRONTEND_URL and localhost origins; block others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health check endpoint (`/health`) to verify system status.
  * Implemented global API versioning with `/api/v1` prefix for all endpoints.
  * Enabled CORS with configurable origin validation to allow requests from specified frontend URLs and localhost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->